### PR TITLE
GH Pages Deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,73 @@
+name: CD
+
+# TODO
+# - Change default branch to main
+# - Change feature/gh-pages-deploy -> main
+# - Comment-out schedule
+
+# NOTE: Don't update this
+on:
+  push:
+    branches:
+      - feature/gh-pages-deploy
+
+  # schedule:
+  #   # Runs "At 00:01. every day" (see https://crontab.guru)
+  #   - cron: '1 0 * * *'
+
+jobs:
+  test_build:
+    name: Run Tests + Build
+    runs-on: ubuntu-latest
+
+    steps:
+      # NOTE: This uses default branch which is `main`
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          ssh-key: ${{secrets.GH_GAATHA_SERVER_SSH_KEY}}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+
+      - name: Install dependencies
+        run: yarn install --prefer-online
+
+      - name: Yarn generate
+        run: yarn generate
+
+      - name: Generate website
+        run: yarn export
+        timeout-minutes: 30
+        env:
+          # Common
+          NODE_OPTIONS: --max_old_space_size=4096
+          # App ENV
+          NEXT_APP_GRAPHQL_ENDPOINT: ${{ vars.NEXT_APP_GRAPHQL_ENDPOINT }}
+
+      - name: Upload GH artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: out/
+
+  deploy:
+    name: Deploy (GH Page)
+    needs: test_build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+      pages: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,19 +1,14 @@
 name: CD
 
-# TODO
-# - Change default branch to main
-# - Change feature/gh-pages-deploy -> main
-# - Comment-out schedule
-
 # NOTE: Don't update this
 on:
   push:
     branches:
-      - feature/gh-pages-deploy
+      - main
 
-  # schedule:
-  #   # Runs "At 00:01. every day" (see https://crontab.guru)
-  #   - cron: '1 0 * * *'
+  schedule:
+    # Runs "At 00:01. every day" (see https://crontab.guru)
+    - cron: '1 0 * * *'
 
 jobs:
   test_build:


### PR DESCRIPTION
- Addresses Deployment

Hosted at: https://gaatha.togglecorp.com/

Also, runs in the schedule
```
  schedule:
    # Runs "At 00:01. every day UTC" (see https://crontab.guru)
    - cron: '1 0 * * *'
```

TODO:
- [x] Change default branch to main
- [x] Change cd.yml feature/gh-pages-deploy -> main
- [x] Comment-out schedule task
- [ ] Reduce size. The current size is ~400MB
- [ ] Use official domain